### PR TITLE
fix up MANY2ONE

### DIFF
--- a/sacrud_deform/__init__.py
+++ b/sacrud_deform/__init__.py
@@ -151,7 +151,7 @@ class SacrudForm(object):
                 if hasattr(relation, 'direction') \
                         and relation.direction == MANYTOMANY:
                     columns.append((relation.key, relation))
-            elif hasattr(column, 'foreign_keys') and column.foreign_keys:
+            if hasattr(column, 'foreign_keys') and column.foreign_keys:
                 relation = self.relationships.get(column, column)
                 column = relation
                 class_member_name = relation.key


### PR DESCRIPTION
Fix for correct work with such type of models:

``` python
class VenueAttribute(Base):
    __tablename__ = 'venue_attribute'
    attribute_id = Column(Integer, ForeignKey('venue_type_attribute.id'),
                          primary_key=True)
    venue_id = Column(Integer, ForeignKey('venue.id'),
                      primary_key=True)
    value = Column(Unicode)
    attribute = relationship('VenueTypeAttribute')
    venue = relationship('Venue')
```
